### PR TITLE
Add theme switcher to mobile header

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -2,15 +2,32 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
 import AppNavigator from './src/navigation/AppNavigator';
-import { ThemeProvider } from './src/theme/ThemeContext';
+import { ThemeProvider, useTheme } from './src/theme/ThemeContext';
 
 export default function App() {
   return (
     <ThemeProvider>
       <NavigationContainer>
-        <StatusBar style="auto" />
+        <ThemedStatusBar />
         <AppNavigator />
       </NavigationContainer>
     </ThemeProvider>
   );
+}
+
+function ThemedStatusBar() {
+  const { theme } = useTheme();
+  const headerBg = theme.colors.headerBg ?? theme.colors.bg;
+  const isDark = colorIsDark(headerBg);
+  return <StatusBar style={isDark ? 'light' : 'dark'} backgroundColor={headerBg} />;
+}
+
+function colorIsDark(hex: string): boolean {
+  let c = hex.replace('#', '');
+  if (c.length === 3) c = c.split('').map((x) => x + x).join('');
+  const r = parseInt(c.slice(0, 2), 16) || 0;
+  const g = parseInt(c.slice(2, 4), 16) || 0;
+  const b = parseInt(c.slice(4, 6), 16) || 0;
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luminance < 140;
 }

--- a/apps/mobile/src/components/ThemeSwitcher.tsx
+++ b/apps/mobile/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,126 @@
+import React, { useMemo, useState } from 'react';
+import { Modal, TouchableOpacity, View, Text, StyleSheet, Pressable } from 'react-native';
+import { useTheme } from '../theme/ThemeContext';
+import type { ThemeName } from '../theme/tokens';
+
+const EMOJI_BY_THEME: Record<ThemeName, string> = {
+  minimal: '🧊',
+  gamer: '🎮',
+  coach: '🧠',
+};
+
+export default function ThemeSwitcher() {
+  const { theme, themeName, setTheme, available } = useTheme();
+  const [open, setOpen] = useState(false);
+
+  const styles = useMemo(() => createStyles(), []);
+
+  const headerTextColor = theme.colors.headerText ?? theme.colors.text;
+
+  return (
+    <>
+      <TouchableOpacity
+        accessibilityRole="button"
+        onPress={() => setOpen(true)}
+        style={[styles.button, { borderColor: theme.colors.border } ]}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <Text style={[styles.emoji, { color: headerTextColor }]}>{EMOJI_BY_THEME[themeName]}</Text>
+      </TouchableOpacity>
+
+      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+        {/* Centered overlay container */}
+        <View style={styles.overlay}>
+          {/* Tap outside to close */}
+          <Pressable style={StyleSheet.absoluteFill} onPress={() => setOpen(false)} />
+
+          <View
+            style={{
+              backgroundColor: theme.colors.card,
+              borderRadius: theme.radii.card,
+              padding: theme.spacing.md,
+              borderWidth: 1,
+              borderColor: theme.colors.border,
+              width: 260,
+            }}
+          >
+            <Text
+              style={{
+                color: theme.colors.text,
+                fontSize: theme.typography.h2,
+                marginBottom: theme.spacing.sm,
+                fontWeight: '600',
+              }}
+            >
+              Tema
+            </Text>
+
+            {available.map((name) => (
+              <TouchableOpacity
+                key={name}
+                onPress={() => {
+                  setTheme(name);
+                  setOpen(false);
+                }}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  paddingVertical: theme.spacing.sm,
+                }}
+              >
+                <Text style={{ fontSize: 20, marginRight: theme.spacing.sm }}>{EMOJI_BY_THEME[name]}</Text>
+                <Text
+                  style={{
+                    color: theme.colors.text,
+                    fontSize: theme.typography.body,
+                    fontWeight: name === themeName ? '700' : '400',
+                  }}
+                >
+                  {labelForTheme(name)}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+function labelForTheme(name: ThemeName): string {
+  switch (name) {
+    case 'minimal':
+      return 'Minimal';
+    case 'gamer':
+      return 'Gamer';
+    case 'coach':
+      return 'Coach';
+    default:
+      return name;
+  }
+}
+
+function createStyles() {
+  return StyleSheet.create({
+    button: {
+      paddingHorizontal: 8,
+      paddingVertical: 6,
+      borderRadius: 999,
+      borderWidth: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      minWidth: 34,
+      minHeight: 34,
+    },
+    emoji: {
+      fontSize: 18,
+    },
+    overlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.3)',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 24,
+    },
+  });
+}

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -3,6 +3,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import TodayScreen from '../screens/TodayScreen';
 import ChatScreen from '../screens/ChatScreen';
 import SettingsScreen from '../screens/SettingsScreen';
+import ThemeSwitcher from '../components/ThemeSwitcher';
+import { useTheme } from '../theme/ThemeContext';
 
 export type RootStackParamList = {
   Today: undefined;
@@ -13,8 +15,19 @@ export type RootStackParamList = {
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function AppNavigator() {
+  const { theme } = useTheme();
+  const headerBg = theme.colors.headerBg ?? theme.colors.bg;
+
   return (
-    <Stack.Navigator initialRouteName="Today">
+    <Stack.Navigator
+      initialRouteName="Today"
+      screenOptions={{
+        headerStyle: { backgroundColor: headerBg },
+        headerTintColor: theme.colors.headerText ?? theme.colors.text,
+        headerShadowVisible: false,
+        headerRight: () => <ThemeSwitcher />,
+      }}
+    >
       <Stack.Screen name="Today" component={TodayScreen} options={{ title: 'Brief del día' }} />
       <Stack.Screen name="Chat" component={ChatScreen} options={{ title: 'Chat' }} />
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: 'Ajustes' }} />


### PR DESCRIPTION
Adds a theme switcher to the mobile app header to allow users to toggle between available themes, ensuring header and status bar colors adapt accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-19eb97b5-627a-465c-8b8b-79b0dc13e111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19eb97b5-627a-465c-8b8b-79b0dc13e111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

