### PR TITLE
Apply current theme styles to main screens

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -85,7 +85,7 @@ function getStyles(theme: Theme) {
     },
     input: {
       flex: 1,
-      height: 40,
+      height: theme.spacing.lg + theme.spacing.md,
       paddingHorizontal: theme.spacing.sm,
       color: theme.colors.text,
       fontSize: theme.typography.body,

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -18,7 +18,11 @@ export default function SettingsScreen() {
           <Text style={styles.label}>Notificaciones</Text>
           <Text style={styles.helper}>Activar recordatorios para el brief</Text>
         </View>
-        <Switch value={notificationsEnabled} onValueChange={() => setNotificationsEnabled((v) => !v)} disabled />
+        <Switch value={notificationsEnabled} onValueChange={() => setNotificationsEnabled((v) => !v)} disabled 
+          trackColor={{ false: theme.colors.border, true: theme.colors.accent }}
+          thumbColor={theme.colors.card}
+          ios_backgroundColor={theme.colors.border}
+        />
       </View>
 
       <View style={styles.row}>

--- a/apps/mobile/src/screens/TodayScreen.tsx
+++ b/apps/mobile/src/screens/TodayScreen.tsx
@@ -194,7 +194,7 @@ function getStyles(theme: Theme) {
       alignItems: 'center',
       borderWidth: 1,
       borderColor: theme.colors.border,
-      shadowColor: '#000',
+      shadowColor: theme.colors.text,
       shadowOpacity: 0.05,
       shadowRadius: 6,
       shadowOffset: { width: 0, height: 2 },
@@ -204,7 +204,7 @@ function getStyles(theme: Theme) {
       fontSize: theme.typography.body,
       fontWeight: '600',
       color: theme.colors.text,
-      marginBottom: 4,
+      marginBottom: theme.spacing.xs,
     },
     cardSubtitle: {
       fontSize: Math.max(12, theme.typography.body - 2),
@@ -215,8 +215,8 @@ function getStyles(theme: Theme) {
       gap: theme.spacing.sm,
     },
     btn: {
-      paddingHorizontal: 12,
-      paddingVertical: 8,
+      paddingHorizontal: theme.spacing.sm + 4,
+      paddingVertical: theme.spacing.xs + 4,
       borderRadius: theme.radii.button,
       borderWidth: 1,
       alignItems: 'center',


### PR DESCRIPTION
Apply current theme styles to `TodayScreen`, `ChatScreen`, and `SettingsScreen` to ensure dynamic theming.

---
<a href="https://cursor.com/background-agent?bcId=bc-b89aebc5-1a8b-4fb5-9179-9d826a74990b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b89aebc5-1a8b-4fb5-9179-9d826a74990b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

